### PR TITLE
location layout: don't create dead links to rooms

### DIFF
--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -11,7 +11,10 @@
   </h1>
 
   {% assign this_room = page %}
-  {% include partials/navbar_rooms.html %}
+
+  {% if site.collections.rooms.output %}
+    {% include partials/navbar_rooms.html %}
+  {% endif %}
 
   {{ content }}
 


### PR DESCRIPTION
if the creation of pages for individual rooms is disabled
the location overview page should not add the corresponding links.